### PR TITLE
Fix typing

### DIFF
--- a/src/tink/json/macros/GenWriter.hx
+++ b/src/tink/json/macros/GenWriter.hx
@@ -149,7 +149,7 @@ class GenWriter {
           },
         });            
     }
-    return ESwitch(macro value, cases, null).at();
+    return ESwitch(macro (value:$ct), cases, null).at();
   }
   
   static public function dyn(e, ct) 


### PR DESCRIPTION
I dunno why, but `value` is `Unknown<0>` here. So we need to type it explicitly.