### PR TITLE
Readme: fix the "Reading" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ For reading, `tink_json` generates a parser based on the expected type. Note tha
 Example:
   
 ```haxe
-
-var o:{ foo: Int, bar:Array<{ flag: Bool }> } = tink.Json.parse('{ "foo": 4, "blub": false, "bar": [{ "flag": true }, { "flag": false, foo: 4 }]}');
-trace(o);//{ foo: 4, bar: [{ flag: true }, { flag: false }]}
+var o:{ foo:Int, bar:Array<{ flag:Bool }> } = tink.Json.parse('{ "foo": 4, "blub": false, "bar": [{ "flag": true }, { "flag": false, "foo": 4 }]}');
+trace(o);//{ bar : [{ flag : true },{ flag : false }], foo : 4 }
 ```
 
 Notice how fields not mentioned in the expected type do not show up.


### PR DESCRIPTION
Due to missing quotes, it produced the following error, rather than the expected trace:

```
Error: Error#422: Expected " at character 70 in ... }, { "flag": false,   ---->  f  <----  oo: 4 }]} @ tink.json.BasicParser.die:237
```

Also, the field order of the traced object is different (and apparently consistently so across different targets, although formatting is a bit different), so I updated that too.