### PR TITLE
Parsed structure

### DIFF
--- a/src/tink/Json.hx
+++ b/src/tink/Json.hx
@@ -15,7 +15,7 @@ class Json {
       switch e {
         case macro ($v : $ct):
           switch ct.toType() {
-            case Success(t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _)) if(t.getID().startsWith('tink.json.Parsed')):
+            case Success(_.reduce() => t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _)) if(t.getID().startsWith('tink.json.Parsed')):
               macro @:pos(e.pos) new tink.json.Parser.ParsedParser<$ct>().tryParse($v);
             default:
               macro @:pos(e.pos) new tink.json.Parser<$ct>().tryParse($v);
@@ -24,7 +24,7 @@ class Json {
           switch Context.getExpectedType() {
             case null:
               e.reject('Cannot determine expected type');
-            case t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _) if(t.getID().startsWith('tink.json.Parsed')):
+            case _.reduce() => t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _) if(t.getID().startsWith('tink.json.Parsed')):
               macro @:pos(e.pos) new tink.json.Parser.ParsedParser<$ct>().tryParse($e);
             case _.toComplex() => ct:
               macro @:pos(e.pos) new tink.json.Parser<$ct>().parse($e);

--- a/src/tink/Json.hx
+++ b/src/tink/Json.hx
@@ -16,7 +16,7 @@ class Json {
         case macro ($v : $ct):
           switch ct.toType() {
             case Success(t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _)) if(t.getID().startsWith('tink.json.Parsed')):
-              macro @:pos(e.pos) new tink.json.Parser<$ct>().tryParsed($v);
+              macro @:pos(e.pos) new tink.json.Parser.ParsedParser<$ct>().tryParse($v);
             default:
               macro @:pos(e.pos) new tink.json.Parser<$ct>().tryParse($v);
           }
@@ -25,7 +25,7 @@ class Json {
             case null:
               e.reject('Cannot determine expected type');
             case t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _) if(t.getID().startsWith('tink.json.Parsed')):
-              macro @:pos(e.pos) new tink.json.Parser<$ct>().parsed($e);
+              macro @:pos(e.pos) new tink.json.Parser.ParsedParser<$ct>().tryParse($e);
             case _.toComplex() => ct:
               macro @:pos(e.pos) new tink.json.Parser<$ct>().parse($e);
           }

--- a/src/tink/Json.hx
+++ b/src/tink/Json.hx
@@ -3,6 +3,8 @@ package tink;
 import haxe.macro.*;
 
 #if macro
+using StringTools;
+using tink.CoreApi;
 using tink.MacroApi;
 #end
 
@@ -11,12 +13,19 @@ class Json {
   static macro public function parse(e:Expr) 
     return 
       switch e {
-        case macro ($e : $ct):
-          macro new tink.json.Parser<$ct>().tryParse($e);
+        case macro ($v : $ct):
+          switch ct.toType() {
+            case Success(t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _)) if(t.getID().startsWith('tink.json.Parsed')):
+              macro @:pos(e.pos) new tink.json.Parser<$ct>().tryParsed($v);
+            default:
+              macro @:pos(e.pos) new tink.json.Parser<$ct>().tryParse($v);
+          }
         case _:
           switch Context.getExpectedType() {
             case null:
               e.reject('Cannot determine expected type');
+            case t = TAbstract(_.get() => {type: TType(_, [_.toComplex() => ct, _])}, _) if(t.getID().startsWith('tink.json.Parsed')):
+              macro @:pos(e.pos) new tink.json.Parser<$ct>().parsed($e);
             case _.toComplex() => ct:
               macro @:pos(e.pos) new tink.json.Parser<$ct>().parse($e);
           }
@@ -26,4 +35,5 @@ class Json {
     var ct = e.typeof().sure().toComplex();
     return macro @:pos(e.pos) new tink.json.Writer<$ct>().write($e);
   }
+  
 }

--- a/src/tink/json/Parsed.hx
+++ b/src/tink/json/Parsed.hx
@@ -5,3 +5,8 @@ class Parsed<T> {}
 
 @:genericBuild(tink.json.macros.Macro.buildParsedFields())
 class ParsedFields<T> {}
+
+typedef ParsedBase<Data, Fields> = {
+	data:Data,
+	fields:Fields,
+}

--- a/src/tink/json/Parsed.hx
+++ b/src/tink/json/Parsed.hx
@@ -1,0 +1,7 @@
+package tink.json;
+
+@:genericBuild(tink.json.macros.Macro.buildParsed())
+class Parsed<T> {}
+
+@:genericBuild(tink.json.macros.Macro.buildParsedFields())
+class ParsedFields<T> {}

--- a/src/tink/json/Parser.hx
+++ b/src/tink/json/Parser.hx
@@ -11,6 +11,13 @@ class Parser<T> {
   
 }
 
+#if !macro
+@:genericBuild(tink.json.macros.Macro.buildParsedParser())
+#end
+class ParsedParser<T> {
+  
+}
+
 private class SliceData {
   
   public var source(default, null):String;

--- a/src/tink/json/macros/GenParsed.hx
+++ b/src/tink/json/macros/GenParsed.hx
@@ -1,0 +1,193 @@
+package tink.json.macros;
+
+import haxe.macro.Context;
+import haxe.macro.Type;
+import haxe.macro.Expr;
+import haxe.ds.Option;
+import tink.typecrawler.Crawler;
+import tink.typecrawler.FieldInfo;
+import tink.typecrawler.Generator;
+
+using haxe.macro.Tools;
+using tink.MacroApi;
+using tink.CoreApi;
+
+class GenParsed {
+  static public var inst = new GenParsed();
+  
+  function new() {}
+  static var SKIP = macro {this.skipValue(); null;}    
+  
+  public function wrap(placeholder:Expr, ct:ComplexType):Function
+    return placeholder.func(macro:tink.json.Parsed.ParsedFields<$ct>);
+  
+  public function nullable(e) 
+    return e;
+    
+  public function string() 
+    return SKIP;
+    
+  public function int() 
+    return SKIP;
+    
+  public function float() 
+    return SKIP;
+    
+  public function bool() 
+    return SKIP;
+    
+  public function date() 
+    return SKIP;
+    
+  public function bytes() 
+    return SKIP;
+    
+  public function map(k, v)               
+    return SKIP;
+    
+  public function anon(fields:Array<FieldInfo>, ct) {
+    
+    var read = macro this.skipValue(),
+        vars:Array<Var> = [],
+        obj:Array<{ field:String, expr:Expr }> = [];
+        
+    for (f in fields) {
+      var ct = f.type.reduce().toComplex(),
+          name = 'v_' + f.name,
+          jsonName = Macro.nativeName(f),
+          optional = f.optional;
+         
+      var hasName = 'has$name';
+
+      read = macro @:pos(f.pos) 
+        if (__name__ == $v{jsonName}) {
+          $i{hasName} = true;
+          $i{name} = ${f.expr};
+        }
+        else $read;
+
+      obj.push({
+        field: f.name,
+        expr: macro {
+          exists: $i{hasName},
+          fields: $i{name},
+        },
+      });
+      vars.push({
+        name: hasName,
+        expr: macro false,
+        type: macro : Bool,
+      });
+      vars.push({
+        name: name,
+        expr: macro null,
+        type: macro:tink.json.Parsed.ParsedFields<$ct>,
+      });
+    };
+        // trace(read.toString());
+    var e = macro {
+      
+      ${EVars(vars).at()};
+      
+      var __start__ = this.pos;
+      this.expect('{');
+      if (!this.allow('}')) {
+        do {
+          var __name__ = this.parseString();
+          this.expect(':');
+          $read;
+        } while (this.allow(','));
+        this.expect('}');
+      }
+        
+      function __missing__(field:String):Dynamic {
+        return this.die('missing field "' + field + '"', __start__);
+      };
+
+      (${EObjectDecl(obj).at()} : tink.json.Parsed.ParsedFields<$ct>);
+    }
+    return e;
+  }  
+  
+  public function array(e) 
+    return SKIP;
+    
+  public function enm(constructors:Array<EnumConstructor>, ct, pos:Position, gen:GenType)
+    return SKIP;
+  
+  public function enumAbstract(names:Array<Expr>, e:Expr, ct:ComplexType, pos:Position):Expr
+    return SKIP;
+  
+  public function dyn(e, ct) 
+    return SKIP;
+    
+  public function dynAccess(e)
+    return SKIP;
+    
+  public function rescue(t:Type, pos:Position, gen:GenType) 
+    return 
+      switch Macro.getRepresentation(t, pos) {
+        case Some(v):
+          var rt = t.toComplex();
+          var ct = v.toComplex();
+          
+          Some(macro @:pos(pos) {
+            var __start__ = this.pos,
+                rep = ${gen(v, pos)};
+                
+            try {
+              (new tink.json.Representation<$ct>(rep) : $rt);
+            }
+            catch (e:Dynamic) {
+              this.die(Std.string(e), __start__);
+            }
+          });
+          
+        default:
+          None;
+      }
+    
+  public function reject(t:Type) 
+    return 'tink_json cannot parse ${t.toString()}. For parsing custom data, please see https://github.com/haxetink/tink_json#custom-abstracts';
+    
+  public function shouldIncludeField(c:ClassField, owner:Option<ClassType>):Bool
+    return Helper.shouldIncludeField(c, owner);
+    
+  public function drive(type:Type, pos:Position, gen:Type->Position->Expr):Expr
+    return 
+      switch type.reduce() {
+        case TDynamic(null): 
+          macro @:pos(pos) this.parseDynamic();
+        case TEnum(_.get().module => 'tink.json.Value', _): 
+          macro @:pos(pos) this.parseValue();
+        case TAbstract(_.get().module => 'tink.json.Serialized', _): 
+          macro @:pos(pos) this.parseSerialized();
+        case v:
+          switch type.getMeta().filter(function (m) return m.has(':jsonParse')) {
+            case []: gen(type, pos);
+            case v: 
+              switch v[0].extract(':jsonParse')[0] {
+                case { params: [parser] }: 
+                  
+                  var path = parser.toString().asTypePath();
+
+                  var rep = 
+                    switch (macro @:pos(parser.pos) new $path(null).parse).typeof().sure().reduce() {
+                      case TFun([{ t: t }], ret): t;
+                      default: parser.reject('field `parse` has wrong signature');
+                    }
+                  macro @:pos(parser.pos) this.plugins.get($parser).parse(${drive(rep, pos, gen)});
+                case v: v.pos.error('@:jsonParse must have exactly one parameter');
+              }
+          }
+        }
+
+}
+
+
+private typedef LiteInfo = {
+  name:String,
+  pos:Position,
+  type:Type,
+  optional:Bool
+}

--- a/src/tink/json/macros/Macro.hx
+++ b/src/tink/json/macros/Macro.hx
@@ -121,7 +121,7 @@ class Macro {
           @:noCompletion @:to public inline function toData():$ct return this.data;
         }
         abs.pack = ['tink', 'json'];
-        abs.kind = TDAbstract(macro:tink.json.$basename, [], []);
+        abs.kind = TDAbstract(macro:tink.json.$basename, [macro:tink.json.$basename], [macro:tink.json.$basename]);
         abs.meta = [{name: ':forward', pos: ctx.pos}];
         abs;
       default: ctx.pos.error('Only supports anonymous structure');

--- a/src/tink/json/macros/Macro.hx
+++ b/src/tink/json/macros/Macro.hx
@@ -153,7 +153,7 @@ class Macro {
   static function parsedFields(ctx:BuildContext):TypeDefinition {
     var name = ctx.name;
     var def = macro class $name {}
-    switch ctx.type {
+    switch ctx.type.reduce() {
       case TAnonymous(_.get() => a):
         for(field in a.fields) {
           var ct = field.type.toComplex();

--- a/tests/ParserTest.hx
+++ b/tests/ParserTest.hx
@@ -113,5 +113,19 @@ class ParserTest {
     return asserts.done();
   }
   
+  public function parsed() {
+    var r = tink.Json.parse(('{"a":1,"sub":{"c":true}}':Parsed<{a:Int, ?b:String, sub:{c:Bool}, ?sub2:{?d:Float}}>));
+    asserts.assert(r.isSuccess());
+    var r = r.sure();
+    asserts.assert(r.data.a == 1);
+    asserts.assert(r.fields.a.exists);
+    asserts.assert(!r.fields.b.exists);
+    asserts.assert(r.fields.sub.exists);
+    asserts.assert(r.fields.sub.fields.c.exists);
+    asserts.assert(!r.fields.sub2.exists);
+    asserts.assert(r.fields.sub2.fields == null);
+    return asserts.done();
+  }
+  
 }
 

--- a/tests/ParserTest.hx
+++ b/tests/ParserTest.hx
@@ -114,18 +114,27 @@ class ParserTest {
   }
   
   public function parsed() {
-    var r = tink.Json.parse(('{"a":1,"sub":{"c":true}}':Parsed<{a:Int, ?b:String, sub:{c:Bool}, ?sub2:{?d:Float}}>));
+    var r = tink.Json.parse(('{"a":1,"s1":{"c":true},"s2":{}}':Parsed<MyParsed>));
     asserts.assert(r.isSuccess());
     var r = r.sure();
     asserts.assert(r.data.a == 1);
     asserts.assert(r.fields.a.exists);
     asserts.assert(!r.fields.b.exists);
-    asserts.assert(r.fields.sub.exists);
-    asserts.assert(r.fields.sub.fields.c.exists);
-    asserts.assert(!r.fields.sub2.exists);
-    asserts.assert(r.fields.sub2.fields == null);
+    asserts.assert(r.fields.s1.exists);
+    asserts.assert(r.fields.s1.fields.c.exists);
+    asserts.assert(r.fields.s2.exists);
+    asserts.assert(!r.fields.s2.fields.d.exists);
+    asserts.assert(!r.fields.s3.exists);
+    asserts.assert(r.fields.s3.fields == null);
     return asserts.done();
   }
-  
+}
+
+typedef MyParsed = {
+  a:Int,
+  ?b:String,
+  s1:{c:Bool},
+  s2:{?d:Bool},
+  ?s3:{?e:Bool},
 }
 


### PR DESCRIPTION
For https://github.com/haxetink/tink_json/issues/30

`Parsed<{str:String, sub:{b:Bool}>` becomes an abstract over the following structure:

```haxe
{
  data:{
    str:String, 
    sub:{
      b:Bool
    },
  },
  fields:{
    str:{
      exists:Bool,
    },
    sub:{
      exists:Bool,
      fields:{
        b:{
          exists:Bool
        }
      }
    }
  }
}
```

Just a prototype, feel free to comment.