### PR TITLE
RFC: Allow @:json({})

### DIFF
--- a/src/tink/json/macros/GenWriter.hx
+++ b/src/tink/json/macros/GenWriter.hx
@@ -190,6 +190,7 @@ class GenWriter extends GenBase {
               switch c.meta.extract(':json') {
                 case []: c.name;
                 case [{ params:[{ expr: EConst(CString(v)) }]}]: v;
+                case [{ params:[{ expr: EBlock([]) }] }]: ExprTools.getValue(EObjectDecl([]).at());
                 case [{ params:[{ expr: EObjectDecl(obj) }] }]: ExprTools.getValue(EObjectDecl(obj).at());
                 case _: c.pos.error('invalid use of @:json');
               }
@@ -207,6 +208,12 @@ class GenWriter extends GenBase {
 
                 c.pos.error('@:json cannot be nullable');
 
+              case [{ params:[{ expr: EBlock([]) }] }]:
+
+                // first = false;
+                var ret = haxe.format.JsonPrinter.print(ExprTools.getValue(EObjectDecl([]).at()));
+                ret.substr(0, ret.length - 1);
+                
               case [{ params:[{ expr: EObjectDecl(obj) }] }]:
 
                 first = false;

--- a/src/tink/json/macros/GenWriter.hx
+++ b/src/tink/json/macros/GenWriter.hx
@@ -190,7 +190,7 @@ class GenWriter extends GenBase {
               switch c.meta.extract(':json') {
                 case []: c.name;
                 case [{ params:[{ expr: EConst(CString(v)) }]}]: v;
-                case [{ params:[{ expr: EBlock([]) }] }]: ExprTools.getValue(EObjectDecl([]).at());
+                case [{ params:[{ expr: EBlock([]) }] }]: {};
                 case [{ params:[{ expr: EObjectDecl(obj) }] }]: ExprTools.getValue(EObjectDecl(obj).at());
                 case _: c.pos.error('invalid use of @:json');
               }
@@ -210,9 +210,7 @@ class GenWriter extends GenBase {
 
               case [{ params:[{ expr: EBlock([]) }] }]:
 
-                // first = false;
-                var ret = haxe.format.JsonPrinter.print(ExprTools.getValue(EObjectDecl([]).at()));
-                ret.substr(0, ret.length - 1);
+                '{';
                 
               case [{ params:[{ expr: EObjectDecl(obj) }] }]:
 

--- a/tests/ParserTest.hx
+++ b/tests/ParserTest.hx
@@ -260,6 +260,14 @@ class ParserTest {
     asserts.assert(!parse(('{}haha': {})).isSuccess());
     return asserts.done();
   }
+  
+  public function anyObject() {
+    asserts.assert(tink.Json.parse(('""':AnyObject)).match(Success(Text)));
+    asserts.assert(tink.Json.parse(('""':AnyInlineObject)).match(Success(Text)));
+    asserts.assert(tink.Json.parse(('{"s":"foo","i":1}':AnyObject)).match(Success(Object(1, 'foo'))));
+    asserts.assert(tink.Json.parse(('{"s":"foo","i":1}':AnyInlineObject)).match(Success(Object({s: 'foo', i: 1}))));
+    return asserts.done();
+  }
 
   static var calls = 0;
   static public function parseFoo(i:Int) {

--- a/tests/Types.hx
+++ b/tests/Types.hx
@@ -188,3 +188,15 @@ typedef OptionalFinal = {
   @:optional final i:Int;
 }
 #end
+
+
+
+enum AnyInlineObject {
+	@:json('') Text;
+	@:json({}) Object(object:{i:Int, s:String});
+}
+
+enum AnyObject {
+	@:json('') Text;
+	@:json({}) Object(i:Int, s:String);
+}

--- a/tests/WriterTest.hx
+++ b/tests/WriterTest.hx
@@ -196,6 +196,14 @@ class WriterTest {
     asserts.assert(stringify(o) == '{"u":2147483648}');
     return asserts.done();
   }
+  
+  public function anyObject() {
+    asserts.assert(tink.Json.stringify(AnyObject.Text) == '""');
+    asserts.assert(tink.Json.stringify(AnyInlineObject.Text) == '""');
+    asserts.assert(tink.Json.stringify(AnyObject.Object(1, 'foo')) == '{"i":1,"s":"foo"}');
+    asserts.assert(tink.Json.stringify(AnyInlineObject.Object({s: 'foo', i: 1})) == '{"i":1,"s":"foo"}');
+    return asserts.done();
+  }
 
   public function testIssue67() {
 


### PR DESCRIPTION
This goal is to allow capturing "any object" in a enum. This should be useful for handling objects that don't have a fixed-value field.