### PR TITLE
Support `@:json({field: _})`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ enum Item {
 }
 ```
 
+### Presence checks and shared enum tags
+
+Within an object tag, `_` means the key must be **present** (the value may still be `null`):
+
+```haxe
+@:json({ jsonrpc: "2.0" })
+enum JsonRpcMessage {
+  @:json({ error: _ })
+  Error(error:{ code:Int, message:String }, id:tink.json.Value);
+
+  @:json({ result: _ })
+  Success(result:tink.json.Value, id:tink.json.Value);
+
+  @:json({ method: _, id: _ })
+  Request(method:String, ?params:tink.json.Value, id:tink.json.Value);
+
+  @:json({ method: _ })
+  Notification(method:String, ?params:tink.json.Value);
+}
+```
+
+- `@:json({ field: _ })` on a constructor requires a **flattened** constructor field named `field` (including fields from the single-object-arg-matching-ctor-name inline convention).
+- `@:json({ ... })` on the **enum type** merges those fields into every object-tagged constructor on write, and requires them on parse (exact value, or presence if `_`). An enum-level `_` presence tag likewise requires that field on every constructor.
+- Optional constructor arguments (`?params`, etc.) follow the same omit rules as optional object fields: `null` means the key is omitted on write (use `Null<T>` or `Option` when you need an explicit `null` — see [Optional Fields and Nulls](#optional-fields-and-nulls)).
+
 ### Dates
 
 Dates are represented simply as floats obtained by calling `getTime()` on a `Date`.

--- a/src/tink/json/macros/GenReader.hx
+++ b/src/tink/json/macros/GenReader.hx
@@ -272,7 +272,22 @@ class GenReader extends GenBase {
   public function enm(constructors:Array<EnumConstructor>, ct:ComplexType, pos:Position, gen:GenType) {
     if(constructors.length == 0) pos.error('Enum ${ct.toString()} has no constructors and tink_json can\'t handle it');
     var fields = new Map<String, LiteInfo>(),
-        cases = new Array<Case>();
+        cases = new Array<Case>(),
+        enumTags = Macro.enumLevelTag(ct, pos),
+        allPresent = new Map<String, Bool>();
+
+    Macro.requireObjectTaggedCtors(enumTags, constructors, pos);
+
+    for (c in constructors) {
+      switch Macro.extractObjectJsonTag(c.ctor.meta) {
+        case null:
+        case ctorTags:
+          final merged = Macro.mergeTags(enumTags, ctorTags, c.ctor.pos);
+          Macro.validatePresentTags(merged, c.fields, c.ctor.pos);
+          for (name in Macro.presentNames(merged).keys())
+            allPresent[name] = true;
+      }
+    }
 
     function captured(f:String)
       return macro @:pos(pos) $i{
@@ -291,6 +306,7 @@ class GenReader extends GenBase {
             type: f.type,
             optional: same.optional || f.optional,
             meta: same.meta.concat(f.meta),
+            presence: same.presence || f.presence,
           }
         case other:
           fields[f.name] = {
@@ -300,10 +316,25 @@ class GenReader extends GenBase {
             type: (macro:tink.json.Serialized<tink.core.Any>).toType().sure(),
             optional: other.optional || f.optional,
             meta: other.meta.concat(f.meta),
+            presence: other.presence || f.presence,
           }
       }
 
     function mkComplex(fields:Iterable<LiteInfo>):ComplexType
+      return TAnonymous([for (f in fields) {
+        name: f.name,
+        pos: f.pos,
+        meta: {
+          final base =
+            if (f.presence) [{ name: ':optional', params: [], pos: f.pos }];
+            else if (f.optional) OPTIONAL;
+            else EXPLICIT;
+          base.concat(f.meta.filter(m -> m.name == ':json'));
+        },
+        kind: FProp(f.access.get, f.access.set, f.type.toComplex()),
+      }]);
+
+    function mkFieldComplex(fields:Iterable<FieldInfo>):ComplexType
       return TAnonymous([for (f in fields) {
         name: f.name,
         pos: f.pos,
@@ -317,18 +348,19 @@ class GenReader extends GenBase {
       var nullable = isInlineNullable(c),
           inlined = c.inlined,
           cfields = c.fields,
-          c = c.ctor,
-          name = c.name,
-          hasArgs = !c.type.reduce().match(TEnum(_,_));
+          ctor = c.ctor,
+          name = ctor.name,
+          hasArgs = !ctor.type.reduce().match(TEnum(_,_));
 
       function mkCase(jsonKey:String) {
         add({
           name: jsonKey,
           optional: true,
-          type: mkComplex(cfields).toType().sure(),
-          pos: c.pos,
+          type: mkFieldComplex(cfields).toType().sure(),
+          pos: ctor.pos,
           access: { get: 'default', set: 'default' },
           meta: [],
+          presence: false,
         });
 
         cases.push({
@@ -350,7 +382,7 @@ class GenReader extends GenBase {
         });
       }
 
-      switch c.meta.extract(':json') {
+      switch ctor.meta.extract(':json') {
         case [] if(!hasArgs):
             argLess.push(new Named(name, name));
         case []:
@@ -362,54 +394,114 @@ class GenReader extends GenBase {
         case [{ params:[{ expr: EConst(CString(v)) }]}] if(!hasArgs):
           argLess.push(new Named(name, v));
 
-        case [{ params:[{ expr: EObjectDecl(obj) }] }]:
+        case [{ params:[{ expr: EObjectDecl(_) }] }]:
+          if (nullable)
+            ctor.pos.error('@:json cannot be nullable');
+
+          final ctorTags = Macro.extractObjectJsonTag(ctor.meta);
+          final merged = Macro.mergeTags(enumTags, ctorTags, ctor.pos);
+
           if(hasArgs) {
             for (f in cfields) {
-              add(f.makeOptional());
+              if (allPresent.exists(f.name)) {
+                add({
+                  pos: f.pos,
+                  name: f.name,
+                  type: Macro.presenceType(f.type),
+                  optional: true,
+                  access: f.access,
+                  meta: f.meta,
+                  presence: true,
+                });
+              } else {
+                final opt = f.makeOptional();
+                add({
+                  pos: opt.pos,
+                  name: opt.name,
+                  type: opt.type,
+                  optional: opt.optional,
+                  access: opt.access,
+                  meta: opt.meta,
+                  presence: false,
+                });
+              }
             }
           }
 
-          for (f in obj)
-            add({
-              pos: f.expr.pos,
-              name: f.field,
-              type: f.expr.typeof().sure(),
-              optional: true,
-              access: { get: 'default', set: 'default' },
-              meta: [],
-            });
+          for (t in merged) switch t {
+            case Const(fname, value):
+              if (!fields.exists(fname))
+                add({
+                  pos: value.pos,
+                  name: fname,
+                  type: value.typeof().sure(),
+                  optional: true,
+                  access: { get: 'default', set: 'default' },
+                  meta: [],
+                  presence: false,
+                });
+            case Present(_):
+          }
 
         case v:
-          c.pos.error('invalid use of @:json');
+          ctor.pos.error('invalid use of @:json');
       }
     }
 
-    // second pass for @:json
+    // second pass for @:json object tags
     for (c in constructors) {
-      switch c.ctor.meta.extract(':json') {
-        case [{ params:[{ expr: EObjectDecl(obj) }] }]:
+      switch Macro.extractObjectJsonTag(c.ctor.meta) {
+        case null:
+        case ctorTags:
+          final merged = Macro.mergeTags(enumTags, ctorTags, c.ctor.pos);
+          final thisPresent = Macro.presentNames(merged);
+          final pat = [],
+              used = new Map<String, Bool>();
+          var guard = macro true;
 
-          var pat = obj.copy(),
-              guard = macro true;
-
-          for(f in c.fields) {
-            if (!(f.optional || isNullable(f.type)))
-              guard = macro $guard && ${captured(f.name)} != null;
-
-            pat.push({ field: f.name, expr: macro ${captured(f.name)}});
+          for (t in merged) switch t {
+            case Const(fname, value):
+              pat.push({ field: fname, expr: value });
+              used[fname] = true;
+            case Present(fname, _):
+              pat.push({ field: fname, expr: macro ${captured(fname)} });
+              used[fname] = true;
+              guard = macro $guard && ${captured(fname)}.match(Some(_));
           }
 
-          function read(f:FieldInfo) {
+          for(f in c.fields) {
+            if (!used.exists(f.name)) {
+              if (!(f.optional || isNullable(f.type)))
+                guard = macro $guard && ${captured(f.name)} != null;
+
+              pat.push({ field: f.name, expr: macro ${captured(f.name)}});
+            }
+          }
+
+          function readField(f:FieldInfo):Expr {
             var e = captured(f.name);
+            if (allPresent.exists(f.name)) {
+              final fct = f.type.toComplex();
+              return if (thisPresent.exists(f.name))
+                macro switch ($e:haxe.ds.Option<$fct>) {
+                  case Some(v): v;
+                  case None: throw new tink.core.Error(422, $v{'Missing field ${f.name}'});
+                }
+              else
+                macro switch ($e:haxe.ds.Option<$fct>) {
+                  case null | None: null;
+                  case Some(v): v;
+                };
+            }
             return if(fields[f.name].type.getID() == 'tink.json.Serialized') {
-              var ct = f.type.toComplex();
+              var fct = f.type.toComplex();
               if(f.optional) {
                 macro {
                   var s = $e;
-                  s == null ? null : (cast s:tink.json.Serialized<$ct>).parse();
+                  s == null ? null : (cast s:tink.json.Serialized<$fct>).parse();
                 }
               } else {
-                macro (cast $e:tink.json.Serialized<$ct>).parse();
+                macro (cast $e:tink.json.Serialized<$fct>).parse();
               }
             } else {
               e;
@@ -417,8 +509,8 @@ class GenReader extends GenBase {
           }
 
           var args =
-            if (c.inlined) [EObjectDecl([for (f in c.fields) { field: f.name, expr: read(f) }]).at(pos)];
-            else [for (f in c.fields) read(f)];
+            if (c.inlined) [EObjectDecl([for (f in c.fields) { field: f.name, expr: readField(f) }]).at(pos)];
+            else [for (f in c.fields) readField(f)];
 
           var call = switch args {
             case []: macro ($i{c.ctor.name} : $ct);
@@ -430,7 +522,6 @@ class GenReader extends GenBase {
             guard: guard,
             expr: call
           });
-        case _:
       }
     }
 
@@ -636,6 +727,7 @@ private typedef LiteInfo = {
   var optional(default, never):Bool;
   var access(default, never):FieldAccessInfo;
   var meta(default, never):Metadata;
+  var presence(default, never):Bool;
 }
 
 private typedef Branch = { ?expr:Expr, children:Map<Int, Branch> };

--- a/src/tink/json/macros/GenSchemaWriter.hx
+++ b/src/tink/json/macros/GenSchemaWriter.hx
@@ -108,27 +108,11 @@ class GenSchemaWriter extends GenBase {
   public function array(e)
     return macro SArray($e);
 
-  // an enhanced version of ExprTools.getValue for EObjectDecl that can also obtain enum abstract fields statically
-  static function getObjectValue(fields:Array<ObjectField>):Dynamic {
-    var obj = {};
-    for (field in fields) {
-      var value =
-        try
-          field.expr.getValue()
-        catch(e:Dynamic)
-          switch Context.typeExpr(field.expr) {
-            case {expr: TCast(e, _)}:
-              Context.getTypedExpr(e).getValue();
-            case te:
-              throw '${te.toString()} does not have a statically known value';
-          }
-      Reflect.setField(obj, field.field, value);
-    }
-    return obj;
-  }
-
   public function enm(constructors:Array<EnumConstructor>, ct:ComplexType, pos:Position, _) {
     if (constructors.length == 0) pos.error('Enum ${ct.toString()} has no constructors and tink_json can\'t handle it');
+
+    final enumTags = Macro.enumLevelTag(ct, pos);
+    Macro.requireObjectTaggedCtors(enumTags, constructors, pos);
 
     var types = [];
     for (c in constructors) {
@@ -138,15 +122,21 @@ class GenSchemaWriter extends GenBase {
           name = ctor.name;
       types.push(
         if (ctor.type.reduce().match(TEnum(_,_)))
-          switch ctor.meta.extract(':json') {
-            case []:
-              macro SPrimitive(PString($v{name}));
-            case [{ params: [{ expr: EConst(CString(v)) }] }]:
-              macro SPrimitive(PString($v{v}));
-            case [{ params: [{ expr: EObjectDecl(obj) }] }]:
-              macro SConst($v{getObjectValue(obj)});
-            case _:
-              ctor.pos.error('invalid use of @:json');
+          switch Macro.extractObjectJsonTag(ctor.meta) {
+            case null:
+              switch ctor.meta.extract(':json') {
+                case []:
+                  macro SPrimitive(PString($v{name}));
+                case [{ params: [{ expr: EConst(CString(v)) }] }]:
+                  macro SPrimitive(PString($v{v}));
+                case _:
+                  ctor.pos.error('invalid use of @:json');
+              }
+            case ctorTags:
+              final merged = Macro.mergeTags(enumTags, ctorTags, ctor.pos);
+              Macro.validatePresentTags(merged, cfields, ctor.pos);
+              // niladic object tag: only const fields (presents already rejected)
+              macro SConst($v{Macro.constTagValues(merged)});
           }
         else
           switch ctor.meta.extract(':json') {
@@ -173,15 +163,32 @@ class GenSchemaWriter extends GenBase {
             case _ if (nullable):
               ctor.pos.error('@:json cannot be nullable');
 
-            case [{ params: [{ expr: EObjectDecl(obj) }] }]:
-              // the discriminator fields are splatted with the constructor arguments
-              var discriminator:Dynamic = getObjectValue(obj);
-              var fields = [for (fname in Reflect.fields(discriminator)) macro {
-                name: $v{fname},
-                type: tink.json.schema.Schema.SchemaType.SConst($v{(Reflect.field(discriminator, fname):Dynamic)}),
-                optional: false,
-              }];
-              macro SObject((${macro $a{fields}}:Array<tink.json.schema.Schema.ObjectFieldSchema>).concat(${objectFields(cfields)}));
+            case [{ params: [{ expr: EObjectDecl(_) }] }]:
+              final ctorTags = Macro.extractObjectJsonTag(ctor.meta);
+              final merged = Macro.mergeTags(enumTags, ctorTags, ctor.pos);
+              Macro.validatePresentTags(merged, cfields, ctor.pos);
+              final byName = [for (f in cfields) f.name => f];
+              final tagFields = [];
+              final seen = new Map<String, Bool>();
+              for (t in merged) switch t {
+                case Const(fname, value):
+                  tagFields.push(macro {
+                    name: $v{fname},
+                    type: tink.json.schema.Schema.SchemaType.SConst($v{Macro.getExprValue(value)}),
+                    optional: false,
+                  });
+                  seen[fname] = true;
+                case Present(fname, _):
+                  final f = byName[fname];
+                  tagFields.push(macro {
+                    name: $v{fname},
+                    type: ${f.expr},
+                    optional: false,
+                  });
+                  seen[fname] = true;
+              }
+              final rest = [for (f in cfields) if (!seen.exists(f.name)) f];
+              macro SObject((${macro $a{tagFields}}:Array<tink.json.schema.Schema.ObjectFieldSchema>).concat(${objectFields(rest)}));
 
             default:
               ctor.pos.error('invalid use of @:json');

--- a/src/tink/json/macros/GenWriter.hx
+++ b/src/tink/json/macros/GenWriter.hx
@@ -181,26 +181,10 @@ class GenWriter extends GenBase {
 
   public function enm(constructors:Array<EnumConstructor>, ct:ComplexType, pos:Position, _) {
     if(constructors.length == 0) pos.error('Enum ${ct.toString()} has no constructors and tink_json can\'t handle it');
-    
-    // an enhanced version of ExprTools.getValue for EObjectDecl that can also obtain enum abstract fields statically
-    function getObjectValue(fields:Array<ObjectField>) {
-      var obj = {};
-      for (field in fields) {
-        var value =
-          try
-            field.expr.getValue()
-          catch(e:Dynamic)
-            switch Context.typeExpr(field.expr) {
-              case {expr: TCast(e, _)}: // TODO: make sure this is what we get when we type an expr of enum abstract field
-                Context.getTypedExpr(e).getValue();
-              case te:
-                throw '${te.toString()} does not have a statically known value';
-            }
-        Reflect.setField(obj, field.field, value);
-      }
-      return obj;
-    }
-    
+
+    final enumTags = Macro.enumLevelTag(ct, pos);
+    Macro.requireObjectTaggedCtors(enumTags, constructors, pos);
+
     var cases = [];
     for (c in constructors) {
       var nullable = isInlineNullable(c),
@@ -214,14 +198,22 @@ class GenWriter extends GenBase {
         if (c.type.reduce().match(TEnum(_,_)))
           {
             values: [macro $i{name}],
-            expr: (macro this.output($v{haxe.format.JsonPrinter.print(
-              switch c.meta.extract(':json') {
-                case []: c.name;
-                case [{ params:[{ expr: EConst(CString(v)) }]}]: v;
-                case [{ params:[{ expr: EObjectDecl(obj) }] }]: getObjectValue(obj);
-                case _: c.pos.error('invalid use of @:json');
+            expr: (macro this.output($v{
+              switch Macro.extractObjectJsonTag(c.meta) {
+                case null:
+                  haxe.format.JsonPrinter.print(
+                    switch c.meta.extract(':json') {
+                      case []: c.name;
+                      case [{ params:[{ expr: EConst(CString(v)) }]}]: v;
+                      case _: c.pos.error('invalid use of @:json');
+                    }
+                  );
+                case ctorTags:
+                  final merged = Macro.mergeTags(enumTags, ctorTags, c.pos);
+                  Macro.validatePresentTags(merged, cfields, c.pos);
+                  Macro.printConstTags(merged);
               }
-            )})),
+            })),
           }
         else {
           var prefix =
@@ -240,11 +232,13 @@ class GenWriter extends GenBase {
 
                 c.pos.error('@:json cannot be nullable');
 
-              case [{ params:[{ expr: EObjectDecl(obj) }] }]:
-
-                first = false;
-                var ret = haxe.format.JsonPrinter.print(getObjectValue(obj));
-                ret.substr(0, ret.length - 1);
+              case [{ params:[{ expr: EObjectDecl(_) }] }]:
+                final ctorTags = Macro.extractObjectJsonTag(c.meta);
+                final merged = Macro.mergeTags(enumTags, ctorTags, c.pos);
+                Macro.validatePresentTags(merged, cfields, c.pos);
+                final p = Macro.objectTagPrefix(merged);
+                first = p.first;
+                p.prefix;
 
               default:
                 c.pos.error('invalid use of @:json');
@@ -260,11 +254,14 @@ class GenWriter extends GenBase {
               this.output($v{prefix});
               if (${if (nullable) macro value == null else macro false}) this.output('null}');
               else {
+                var __first = $v{first};
                 $b{[for (f in cfields) {
                   var fname = f.name;
-                  macro {
-                    this.output($v{'${if (first) { first = false; ""; } else ","}"${Macro.nativeName(f)}"'});
-                    this.char(':'.code);
+                  var field = '"${Macro.nativeName(f)}":';
+                  var writeField = macro {
+                    if (__first) __first = false;
+                    else this.char(','.code);
+                    this.output($v{field});
                     {
                       var value = ${
                         if (inlined)
@@ -274,7 +271,11 @@ class GenWriter extends GenBase {
                       }
                       ${f.expr};
                     }
-                  }
+                  };
+                  if (f.optional) {
+                    final read = if (inlined) macro value.$fname else macro $i{f.name};
+                    macro if ($read != null) $writeField;
+                  } else writeField;
                 }]}
                 this.output($v{postfix});
               }

--- a/src/tink/json/macros/Macro.hx
+++ b/src/tink/json/macros/Macro.hx
@@ -8,10 +8,17 @@ import haxe.ds.Option;
 import tink.macro.BuildCache;
 
 import tink.typecrawler.*;
+import tink.typecrawler.Generator.EnumConstructor;
 
 using haxe.macro.Tools;
 using StringTools;
 using tink.MacroApi;
+using tink.CoreApi;
+
+enum JsonTagField {
+  Const(name:String, value:Expr);
+  Present(name:String, pos:Position);
+}
 
 class Macro {
 
@@ -68,6 +75,143 @@ class Macro {
         case [{ params:[{ expr: EConst(CString(v)) }]}]: v;
         case v: c.pos.error('invalid use of @:json');
       }
+
+  static public function isUnderscore(e:Expr):Bool
+    return switch e {
+      case { expr: EConst(CIdent('_')) }: true;
+      case _: false;
+    }
+
+  static public function parseJsonTagFields(obj:Array<ObjectField>):Array<JsonTagField> {
+    final out = [];
+    for (f in obj) {
+      if (isUnderscore(f.expr))
+        out.push(Present(f.field, f.expr.pos));
+      else
+        out.push(Const(f.field, f.expr));
+    }
+    return out;
+  }
+
+  static public function extractObjectJsonTag(meta:MetaAccess):Null<Array<JsonTagField>>
+    return switch meta.extract(':json') {
+      case []: null;
+      case [{ params: [{ expr: EObjectDecl(obj) }] }]: parseJsonTagFields(obj);
+      case [{ params: [{ expr: EConst(CString(_)) }] }]: null;
+      case [m]: m.pos.error('invalid use of @:json');
+      case v: v[1].pos.error('duplicate @:json metadata not allowed');
+    }
+
+  static public function enumLevelTag(ct:ComplexType, pos:Position):Array<JsonTagField> {
+    final t = switch ct.toType() {
+      case Success(t): t;
+      case Failure(e): return pos.error(e.message);
+    }
+    return switch t.reduce() {
+      case TEnum(_.get() => e, _):
+        switch e.meta.extract(':json') {
+          case []: [];
+          case [{ params: [{ expr: EObjectDecl(obj) }] }]: parseJsonTagFields(obj);
+          case [m]: m.pos.error('@:json on enum type must be an object literal');
+          case v: v[1].pos.error('duplicate @:json metadata not allowed on enum type');
+        }
+      case _: [];
+    }
+  }
+
+  static public function isObjectTaggedCtor(c:EnumField):Bool
+    return switch c.meta.extract(':json') {
+      case [{ params: [{ expr: EObjectDecl(_) }] }]: true;
+      case _: false;
+    }
+
+  static public function mergeTags(enumLevel:Array<JsonTagField>, ctorLevel:Array<JsonTagField>, pos:Position):Array<JsonTagField> {
+    final byName = new Map<String, Bool>();
+    final out = [];
+    function add(t:JsonTagField) {
+      final name = switch t {
+        case Const(n, _): n;
+        case Present(n, _): n;
+      }
+      if (byName.exists(name))
+        pos.error('Duplicate @:json tag field "$name" across enum-level and constructor-level metadata');
+      byName[name] = true;
+      out.push(t);
+    }
+    for (t in enumLevel) add(t);
+    for (t in ctorLevel) add(t);
+    return out;
+  }
+
+  static public function validatePresentTags(tags:Array<JsonTagField>, fields:Array<FieldInfo>, pos:Position) {
+    final names = [for (f in fields) f.name => true];
+    for (t in tags) switch t {
+      case Present(name, p) if (!names.exists(name)):
+        p.error('@:json({ $name: _ }) requires a constructor field named "$name"');
+      case Const(name, value) if (names.exists(name)):
+        value.pos.error('@:json const tag "$name" collides with a constructor field of the same name');
+      case _:
+    }
+  }
+
+  static public function requireObjectTaggedCtors(enumLevel:Array<JsonTagField>, constructors:Array<EnumConstructor>, pos:Position) {
+    if (enumLevel.length == 0) return;
+    for (c in constructors)
+      if (!isObjectTaggedCtor(c.ctor))
+        c.ctor.pos.error('Enum-level @:json requires every constructor to use @:json({...}) object tags');
+  }
+
+  static public function printConstTags(tags:Array<JsonTagField>):String {
+    final parts = [];
+    for (t in tags) switch t {
+      case Const(name, value):
+        parts.push(haxe.format.JsonPrinter.print(name) + ':' + haxe.format.JsonPrinter.print(getExprValue(value)));
+      case Present(_):
+    }
+    return '{' + parts.join(',') + '}';
+  }
+
+  static public function objectTagPrefix(tags:Array<JsonTagField>):{ prefix:String, first:Bool } {
+    final printed = printConstTags(tags);
+    if (printed == '{}')
+      return { prefix: '{', first: true };
+    return { prefix: printed.substr(0, printed.length - 1), first: false };
+  }
+
+  static public function constTagValues(tags:Array<JsonTagField>):Dynamic {
+    final obj = {};
+    for (t in tags) switch t {
+      case Const(name, value):
+        Reflect.setField(obj, name, getExprValue(value));
+      case Present(_):
+    }
+    return obj;
+  }
+
+  static public function getExprValue(e:Expr):Dynamic
+    return
+      try e.getValue()
+      catch (err:Dynamic)
+        switch Context.typeExpr(e) {
+          case { expr: TCast(te, _) }:
+            Context.getTypedExpr(te).getValue();
+          case te:
+            e.pos.error('${te.toString()} does not have a statically known value');
+        }
+
+  static public function presenceType(t:Type):Type {
+    final ct = t.toComplex({ direct: true });
+    return (macro : haxe.ds.Option<$ct>).toType().sure();
+  }
+
+  static public function presentNames(tags:Array<JsonTagField>):Map<String, Bool> {
+    final m = new Map();
+    for (t in tags) switch t {
+      case Present(name, _): m[name] = true;
+      case _:
+    }
+    return m;
+  }
 
 
   static function parser(ctx:BuildContext):TypeDefinition {

--- a/tests/ParserTest.hx
+++ b/tests/ParserTest.hx
@@ -265,6 +265,30 @@ class ParserTest {
     return asserts.done();
   }
 
+  public function jsonRpcMessages() {
+    asserts.assert(parse(('{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request"},"id":null}':JsonRpcMessage)).match(Success(JsonRpcMessage.Error(_, VNull))));
+    asserts.assert(parse(('{"jsonrpc":"2.0","result":null,"id":1}':JsonRpcMessage)).match(Success(JsonRpcMessage.Success(VNull, VNumber(1)))));
+    asserts.assert(parse(('{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":null}':JsonRpcMessage)).match(Success(JsonRpcMessage.Request('sum', _, VNull))));
+    asserts.assert(parse(('{"jsonrpc":"2.0","method":"notify"}':JsonRpcMessage)).match(Success(JsonRpcMessage.Notification('notify', null))));
+    asserts.assert(parse(('{"jsonrpc":"2.0","method":"m"}':JsonRpcMessage)).match(Success(JsonRpcMessage.Notification('m', null))));
+    asserts.assert(parse(('{"jsonrpc":"2.0","method":"m","id":1}':JsonRpcMessage)).match(Success(JsonRpcMessage.Request('m', null, VNumber(1)))));
+    asserts.assert(parse(('{"jsonrpc":"1.0","method":"notify"}':JsonRpcMessage)).match(Failure(_)));
+    return asserts.done();
+  }
+
+  public function presenceAndInline() {
+    asserts.assert(parse(('{"v":"1","type":"circle","radius":1.5}':PresenceShape)).match(Success(Circle({ radius: 1.5 }))));
+    asserts.assert(parse(('{"v":"1","type":"rect","w":2,"h":3}':PresenceShape)).match(Success(Rect({ w: 2, h: 3 }))));
+    asserts.assert(parse(('{"v":"1","type":"rect","h":3}':PresenceShape)).match(Failure(_)));
+    asserts.assert(parse(('{"kind":"msg","payload":null}':PresenceOnly)).match(Success(WithPayload(null, null))));
+    asserts.assert(parse(('{"kind":"msg","empty":true}':PresenceOnly)).match(Success(Empty)));
+    asserts.assert(parse(('{"kind":"msg"}':PresenceOnly)).match(Failure(_)));
+    asserts.assert(parse(('{"kind":"other"}':PresenceOnly)).match(Failure(_)));
+    asserts.assert(parse(('{"marker":1}':OmitOptional)).match(Success(OmitOptional.A(null, 1, null))));
+    asserts.assert(parse(('{"skip":2,"marker":1,"tail":"x"}':OmitOptional)).match(Success(OmitOptional.A(2, 1, 'x'))));
+    return asserts.done();
+  }
+
   public function privateEnumAbstract() {
     asserts.assert(parse(('0':VeryPrivate)).match(Success(VeryPrivate.A)));
     asserts.assert(parse(('{"foo":1}':{foo:VeryPrivate})).match(Success({foo:VeryPrivate.B})));

--- a/tests/SchemaWriterTest.hx
+++ b/tests/SchemaWriterTest.hx
@@ -116,6 +116,28 @@ class SchemaWriterTest {
 		return asserts.done();
 	}
 	
+	public function writePresenceShape() {
+		final schema = tink.Json.schema(PresenceShape);
+		final output = JsonSchema.write(schema);
+		asserts.assert(output.indexOf('"const":"1"') > 0);
+		asserts.assert(output.indexOf('"const":"circle"') > 0);
+		asserts.assert(output.indexOf('"const":"rect"') > 0);
+		asserts.assert(output.indexOf('"radius"') > 0);
+		asserts.assert(output.indexOf('"w"') > 0);
+		return asserts.done();
+	}
+
+	public function writeJsonRpcMessage() {
+		final output = JsonSchema.write(tink.Json.schema(JsonRpcMessage));
+		asserts.assert(output.indexOf('"const":"2.0"') > 0);
+		asserts.assert(output.indexOf('"error"') > 0);
+		asserts.assert(output.indexOf('"result"') > 0);
+		asserts.assert(output.indexOf('"method"') > 0);
+		asserts.assert(output.indexOf('"id"') > 0);
+		asserts.assert(output.indexOf('"params"') > 0);
+		return asserts.done();
+	}
+	
 	#if nodejs
 	@:variant(tink.Json.schema(String), [tink.Json.stringify('foo')], ['1'])
 	@:variant(tink.Json.schema(Int), [tink.Json.stringify(1)], ['"1"'])

--- a/tests/Types.hx
+++ b/tests/Types.hx
@@ -239,3 +239,47 @@ abstract NotFloat(Float) {
   public inline function new(v) this = v;
   public inline function toFloat() return this;
 }
+
+typedef JsonRpcErrorObject = {
+  final code:Int;
+  final message:String;
+}
+
+@:json({ jsonrpc: "2.0" })
+enum JsonRpcMessage {
+  @:json({ error: _ })
+  Error(error:JsonRpcErrorObject, id:tink.json.Value);
+
+  @:json({ result: _ })
+  Success(result:tink.json.Value, id:tink.json.Value);
+
+  @:json({ method: _, id: _ })
+  Request(method:String, ?params:tink.json.Value, id:tink.json.Value);
+
+  @:json({ method: _ })
+  Notification(method:String, ?params:tink.json.Value);
+}
+
+@:json({ v: "1" })
+enum PresenceShape {
+  @:json({ type: "circle" })
+  Circle(Circle:{ radius:Float });
+
+  @:json({ type: "rect", w: _ })
+  Rect(Rect:{ w:Float, h:Float });
+}
+
+@:json({ kind: "msg" })
+enum PresenceOnly {
+  @:json({ payload: _ })
+  WithPayload(payload:Null<String>, ?extra:Int);
+
+  @:json({ empty: true })
+  Empty;
+}
+
+/** No const tags in the JSON prefix — exercises runtime comma handling when optionals are omitted. */
+enum OmitOptional {
+  @:json({ marker: _ })
+  A(?skip:Int, marker:Int, ?tail:String);
+}

--- a/tests/WriterTest.hx
+++ b/tests/WriterTest.hx
@@ -254,6 +254,31 @@ class WriterTest {
     asserts.assert(tink.Json.stringify(o) == '{"foo":0.5}');
     return asserts.done();
   }
+
+  public function jsonRpcMessages() {
+    asserts.assert(stringify(JsonRpcMessage.Error({ code: -32600, message: 'Invalid Request' }, VNull)) == '{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request"},"id":null}');
+    asserts.assert(stringify(JsonRpcMessage.Success(VNull, VNumber(1))) == '{"jsonrpc":"2.0","result":null,"id":1}');
+    asserts.assert(stringify(JsonRpcMessage.Request('sum', VArray([VNumber(1), VNumber(2)]), VNull)) == '{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":null}');
+    asserts.assert(stringify(JsonRpcMessage.Request('sum', null, VNull)) == '{"jsonrpc":"2.0","method":"sum","id":null}');
+    asserts.assert(stringify(JsonRpcMessage.Notification('notify', null)) == '{"jsonrpc":"2.0","method":"notify"}');
+    return asserts.done();
+  }
+
+  public function presenceAndInline() {
+    asserts.assert(stringify(Circle({ radius: 1.5 })) == '{"v":"1","type":"circle","radius":1.5}');
+    asserts.assert(stringify(Rect({ w: 2, h: 3 })) == '{"v":"1","type":"rect","h":3,"w":2}');
+    asserts.assert(stringify(WithPayload(null)) == '{"kind":"msg","payload":null}');
+    asserts.assert(stringify(Empty) == '{"kind":"msg","empty":true}');
+    return asserts.done();
+  }
+
+  public function omitOptionalEnumFields() {
+    asserts.assert(stringify(Staff(.5)) == '{"type":"staff","block":0.5}');
+    asserts.assert(stringify(OmitOptional.A(null, 1)) == '{"marker":1}');
+    asserts.assert(stringify(OmitOptional.A(2, 1)) == '{"skip":2,"marker":1}');
+    asserts.assert(stringify(OmitOptional.A(null, 1, 'x')) == '{"marker":1,"tail":"x"}');
+    return asserts.done();
+  }
 }
 
 abstract Opacity(Float) from Float to Float {


### PR DESCRIPTION
Adds two ways to shape object-tagged enums in JSON:
1. **Presence tags** — `@:json({ field: _ })` means “this key must exist” (value may still be `null`). Useful when variants share keys and differ only by which fields show up (e.g. JSON-RPC `Request` has `id`, `Notification` does not).
2. **Enum-level tags** — `@:json({ ... })` on the enum itself is merged into every object-tagged constructor (e.g. shared `"jsonrpc": "2.0"`).
Also makes optional constructor args omit `null` on write, matching how optional object fields already work.
